### PR TITLE
BnModelObserver recieves named PropertyChangeEvents

### DIFF
--- a/beanfabrics-core/src/main/java/org/beanfabrics/BnModelObserver.java
+++ b/beanfabrics-core/src/main/java/org/beanfabrics/BnModelObserver.java
@@ -19,7 +19,7 @@ import org.beanfabrics.model.PresentationModel;
  * {@link PropertyChangeEvent} (with property name "presentationModel") whenever
  * the model reference or the model properties change. The method
  * {@link #getPresentationModel()} returns that model.
- * 
+ *
  * @author Michael Karneim
  * @beaninfo
  */
@@ -27,7 +27,7 @@ import org.beanfabrics.model.PresentationModel;
 public class BnModelObserver extends AbstractBean implements View<PresentationModel>, ModelSubscriber {
     private final PropertyChangeListener listener = new WeakPropertyChangeListener() {
         public void propertyChange(PropertyChangeEvent evt) {
-            BnPropertyChangeEvent nextEvent = new BnPropertyChangeEvent(BnModelObserver.this, "presentationModel", null, null, evt);
+            BnPropertyChangeEvent nextEvent = new BnPropertyChangeEvent(BnModelObserver.this, evt.getPropertyName(), null, null, evt);
             getPropertyChangeSupport().firePropertyChange(nextEvent);
         }
     };
@@ -43,7 +43,7 @@ public class BnModelObserver extends AbstractBean implements View<PresentationMo
     /**
      * Returns whether this observer is connected to any
      * {@link PresentationModel}
-     * 
+     *
      * @return <code>true</code> if this component is connected, else
      *         <code>false</code>
      */

--- a/beanfabrics-core/src/main/java/org/beanfabrics/event/BnPropertyChangeSupport.java
+++ b/beanfabrics-core/src/main/java/org/beanfabrics/event/BnPropertyChangeSupport.java
@@ -24,7 +24,7 @@ import java.util.WeakHashMap;
 /**
  * The {@link BnPropertyChangeSupport} is a utility class for handling listeners
  * of bound properties.
- * 
+ *
  * @author Michael Karneim
  */
 public class BnPropertyChangeSupport {
@@ -44,7 +44,7 @@ public class BnPropertyChangeSupport {
 
     /**
      * Constructs a {@link BnPropertyChangeSupport}.
-     * 
+     *
      * @param sourceBean The bean to be given as the source for any events
      */
     public BnPropertyChangeSupport(Object sourceBean) {
@@ -57,7 +57,7 @@ public class BnPropertyChangeSupport {
     /**
      * Adds the given {@link PropertyChangeListener} for any property of the
      * source bean.
-     * 
+     *
      * @param listener the listener add
      */
     public synchronized void addPropertyChangeListener(PropertyChangeListener listener) {
@@ -74,7 +74,7 @@ public class BnPropertyChangeSupport {
 
     /**
      * Removes the given {@link PropertyChangeListener}.
-     * 
+     *
      * @param listener the listener to remove
      */
     public synchronized void removePropertyChangeListener(PropertyChangeListener listener) {
@@ -93,7 +93,7 @@ public class BnPropertyChangeSupport {
      * Adds the given {@link PropertyChangeListener} for the specified property
      * of the source bean. The listener will only receive events that are
      * triggered by that property.
-     * 
+     *
      * @param propertyName the name of the property
      * @param listener the listener to add
      */
@@ -115,7 +115,7 @@ public class BnPropertyChangeSupport {
 
     /**
      * Removes the given {@link PropertyChangeListener} for a specific property.
-     * 
+     *
      * @param propertyName the name of the property
      * @param listener the listener to remove
      */
@@ -138,7 +138,7 @@ public class BnPropertyChangeSupport {
     /**
      * Report a bound property update to each registered listener. No event is
      * fired if old and new are equal and non-null.
-     * 
+     *
      * @param propertyName the property name of the property that was changed
      * @param oldValue the old value of the property
      * @param newValue the new value of the property
@@ -150,7 +150,7 @@ public class BnPropertyChangeSupport {
     /**
      * Report a bound property update to each registered listener. No event is
      * fired if old and new are equal and non-null.
-     * 
+     *
      * @param propertyName the property name of the property that was changed
      * @param oldValue the old value of the property
      * @param newValue the new value of the property
@@ -187,10 +187,10 @@ public class BnPropertyChangeSupport {
     }
 
     /**
-     * Fire thw given {@link PropertyChangeEvent} to each registered listener.
+     * Fire the given {@link PropertyChangeEvent} to each registered listener.
      * No event is fired if the given event's old and new values are equal and
      * non-<code>null</code>.
-     * 
+     *
      * @param evt the <code>PropertyChangeEvent</code> object
      */
     public void firePropertyChange(BnPropertyChangeEvent evt) {
@@ -226,7 +226,7 @@ public class BnPropertyChangeSupport {
     /**
      * Returns <code>true</code> if there are any listeners for the property
      * with the specified name.
-     * 
+     *
      * @param propertyName the property name
      * @return <code>true</code> if there are any listeners
      */
@@ -246,7 +246,7 @@ public class BnPropertyChangeSupport {
 
     /**
      * Returns <code>true</code> if there are any listeners registered at all.
-     * 
+     *
      * @return <code>true</code> if there are any listeners for any property
      */
     public boolean hasListeners() {
@@ -255,7 +255,7 @@ public class BnPropertyChangeSupport {
 
     /**
      * Returns the {@link WeakWrapper} for the given listener.
-     * 
+     *
      * @param l
      * @return the WeakWrapper for the given listener
      */
@@ -270,7 +270,7 @@ public class BnPropertyChangeSupport {
 
     /**
      * Removes the given {@link WeakWrapper} from the weakWrapper cache.
-     * 
+     *
      * @param wrapper
      */
     private void removeWeakWrapper(WeakWrapper wrapper) {
@@ -280,7 +280,7 @@ public class BnPropertyChangeSupport {
     /**
      * Removes all unused WeakWrapper instances from the given list of
      * listeners.
-     * 
+     *
      * @param listeners
      */
     private void removeUnusedWeakWrappers(Collection<PropertyChangeListener> listeners) {
@@ -303,7 +303,7 @@ public class BnPropertyChangeSupport {
 
         /**
          * Constructs a {@link WeakWrapper} for the given delegate.
-         * 
+         *
          * @param aDelegate
          */
         WeakWrapper(PropertyChangeListener aDelegate) {
@@ -313,7 +313,7 @@ public class BnPropertyChangeSupport {
         /**
          * Returns <code>true</code>, if the delegate reference has been
          * cleared.
-         * 
+         *
          * @return <code>true</code>, if the delegate reference has been cleared
          */
         boolean isCleared() {
@@ -331,7 +331,7 @@ public class BnPropertyChangeSupport {
 
         /**
          * Returns the delegate.
-         * 
+         *
          * @return the delegate
          */
         PropertyChangeListener getDelegate() {
@@ -343,7 +343,7 @@ public class BnPropertyChangeSupport {
 
         /**
          * Sets the delegate.
-         * 
+         *
          * @param aDelegate
          */
         void setDelegate(PropertyChangeListener aDelegate) {

--- a/beanfabrics-core/src/test/java/org/beanfabrics/BnModelObserverTest.java
+++ b/beanfabrics-core/src/test/java/org/beanfabrics/BnModelObserverTest.java
@@ -7,8 +7,8 @@ import static org.junit.Assert.assertTrue;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.EventObject;
-
-import junit.framework.JUnit4TestAdapter;
+import java.util.LinkedList;
+import java.util.List;
 
 import org.beanfabrics.event.BnPropertyChangeEvent;
 import org.beanfabrics.model.AbstractPM;
@@ -16,6 +16,8 @@ import org.beanfabrics.model.PMManager;
 import org.beanfabrics.model.TextPM;
 import org.beanfabrics.support.Validation;
 import org.junit.Test;
+
+import junit.framework.JUnit4TestAdapter;
 
 /**
  * @author Michael Karneim
@@ -75,10 +77,8 @@ public class BnModelObserverTest {
             public void propertyChange(PropertyChangeEvent evt) {
                 //printEvent("", evt);
 
-                if ("presentationModel".equals(evt.getPropertyName())) {
-                    count[0]++;
-                    isValid[0] = pm.isValid();
-                }
+                count[0]++;
+                isValid[0] = pm.isValid();
             }
 
             private void printEvent(String prefix, EventObject evt) {
@@ -94,6 +94,54 @@ public class BnModelObserverTest {
         assertFalse("pm.isValid()", pm.isValid());
         assertEquals("count[0]", 3, count[0]);
         assertEquals("isValid[0]", false, isValid[0]);
+    }
+
+    @Test
+    public void test_BnModelObserver_recieves_property_change_events() {
+      // given:
+      final AbstractPM pm = new AbstractPM() {};
+
+      ModelProvider prov = new ModelProvider();
+      prov.setPresentationModel(pm);
+
+      BnModelObserver observer = new BnModelObserver();
+      observer.setModelProvider(prov);
+      observer.setPath(new Path());
+
+      final List<PropertyChangeEvent> events = new LinkedList<PropertyChangeEvent>();
+      observer.addPropertyChangeListener(new PropertyChangeListener() {
+        public void propertyChange(PropertyChangeEvent evt) {
+          events.add(evt);
+        }
+      });
+      // when:
+      pm.getPropertyChangeSupport().firePropertyChange(null, null, null);
+      // then
+      assertEquals("events.size()", events.size(), 1);
+    }
+
+    @Test
+    public void test_BnModelObserver_recieves_named_property_change_events() {
+      // given:
+      final AbstractPM pm = new AbstractPM() {};
+
+      ModelProvider prov = new ModelProvider();
+      prov.setPresentationModel(pm);
+
+      BnModelObserver observer = new BnModelObserver();
+      observer.setModelProvider(prov);
+      observer.setPath(new Path());
+
+      final List<PropertyChangeEvent> events = new LinkedList<PropertyChangeEvent>();
+      observer.addPropertyChangeListener("my property change", new PropertyChangeListener() {
+        public void propertyChange(PropertyChangeEvent evt) {
+          events.add(evt);
+        }
+      });
+      // when:
+      pm.getPropertyChangeSupport().firePropertyChange("my property change", null, null);
+      // then
+      assertEquals("events.size()", events.size(), 1);
     }
 
 }

--- a/beanfabrics-core/src/test/java/org/beanfabrics/validation/CompositeValidationStateTest.java
+++ b/beanfabrics-core/src/test/java/org/beanfabrics/validation/CompositeValidationStateTest.java
@@ -120,10 +120,8 @@ public class CompositeValidationStateTest {
             public void propertyChange(PropertyChangeEvent evt) {
                 //				printEvent("", evt);
 
-                if ("presentationModel".equals(evt.getPropertyName())) {
-                    count[0]++;
-                    isValid[0] = ob.getPresentationModel().isValid();
-                }
+                count[0]++;
+                isValid[0] = ob.getPresentationModel().isValid();
             }
 
             //			private void printEvent(String prefix, EventObject evt) {


### PR DESCRIPTION
This fixes #17.
This might not be the optimal way of fixing that issue, because the whole concept of `org.beanfabrics.event.FollowUpEvent` is questionable in my opinion.
A review of the changes made here is advised.